### PR TITLE
Allow Optional on Pydantic for List

### DIFF
--- a/src/jmux/demux.py
+++ b/src/jmux/demux.py
@@ -260,7 +260,7 @@ class JMux(ABC):
             and len(pydantic_subtype_set) > 0
         ) or len(jmux_main_type_set) != 1:
             wrong_obj = "pydantic" if pydantic_wrong else "JMux"
-            wrong_set = jmux_main_type_set if pydantic_wrong else pydantic_main_type_set
+            wrong_set = pydantic_main_type_set if pydantic_wrong else jmux_main_type_set
             raise ForbiddenTypeHintsError(
                 message=(f"Forbidden typing received on {wrong_obj}: {wrong_set}"),
             )
@@ -281,22 +281,20 @@ class JMux(ABC):
                 )
             )
 
-        if not any(
-            issubclass(elem, t)
-            for t in (int, float, str, bool, NoneType, JMux, Enum)
-            for elem in jmux_subtype_set
+        if not cls._all_elements_in_set_a_are_subclass_of_an_element_in_set_b(
+            set_a=jmux_subtype_set,
+            set_b={int, float, str, bool, NoneType, JMux, Enum},
         ):
             raise ForbiddenTypeHintsError(
                 message=(
-                    "JMux sub type must be one of the emittable types: "
+                    "JMux sub type must be one of the emittable types, got: "
                     f"{jmux_subtype_set}."
                 )
             )
 
-        if len(pydantic_subtype_set) > 0 and not any(
-            issubclass(elem, t)
-            for t in (int, float, str, bool, NoneType, BaseModel, Enum)
-            for elem in pydantic_subtype_set
+        if not cls._all_elements_in_set_a_are_subclass_of_an_element_in_set_b(
+            set_a=pydantic_subtype_set,
+            set_b={int, float, str, bool, NoneType, BaseModel, Enum},
         ):
             raise ForbiddenTypeHintsError(
                 message=(
@@ -305,10 +303,9 @@ class JMux(ABC):
                 )
             )
 
-        if not any(
-            issubclass(elem, t)
-            for t in (int, float, str, bool, list, NoneType, BaseModel, Enum)
-            for elem in pydantic_main_type_set
+        if not cls._all_elements_in_set_a_are_subclass_of_an_element_in_set_b(
+            set_a=pydantic_main_type_set,
+            set_b={int, float, str, bool, list, NoneType, BaseModel, Enum},
         ):
             raise ForbiddenTypeHintsError(
                 message=(
@@ -316,6 +313,12 @@ class JMux(ABC):
                     f"or BaseModel, got {pydantic_main_type_set}."
                 )
             )
+
+    @classmethod
+    def _all_elements_in_set_a_are_subclass_of_an_element_in_set_b(
+        cls, set_a: Set[Type], set_b: Set[Type]
+    ) -> bool:
+        return all(any(issubclass(elem, t) for t in set_b) for elem in set_a)
 
     @classmethod
     def _assert_is_allowed_streamable_values(

--- a/src/jmux/demux.py
+++ b/src/jmux/demux.py
@@ -216,17 +216,11 @@ class JMux(ABC):
                 pydantic_main_type_set,
                 pydantic_subtype_set,
             )
-            if (
-                pydantic_wrong := len(pydantic_main_type_set) != 1
-                and len(pydantic_subtype_set) > 0
-            ) or len(jmux_main_type_set) != 1:
-                wrong_obj = "pydantic" if pydantic_wrong else "JMux"
-                wrong_set = (
-                    jmux_main_type_set if pydantic_wrong else pydantic_main_type_set
-                )
-                raise ForbiddenTypeHintsError(
-                    message=(f"Forbidden typing received on {wrong_obj}: {wrong_set}"),
-                )
+            cls._assert_correct_set_combinations(
+                jmux_main_type_set,
+                pydantic_main_type_set,
+                pydantic_subtype_set,
+            )
 
             if StreamableValues in jmux_main_type_set:
                 cls._assert_is_allowed_streamable_values(
@@ -251,6 +245,77 @@ class JMux(ABC):
                     attribute=attr_name,
                     message="Unexpected main type on JMux",
                 )
+
+    @classmethod
+    def _assert_correct_set_combinations(
+        cls,
+        jmux_main_type_set: Set[Type],
+        pydantic_main_type_set: Set[Type],
+        pydantic_subtype_set: Set[Type],
+    ):
+        if (
+            pydantic_wrong := (
+                len(pydantic_main_type_set) != 1 and list not in pydantic_main_type_set
+            )
+            and len(pydantic_subtype_set) > 0
+        ) or len(jmux_main_type_set) != 1:
+            wrong_obj = "pydantic" if pydantic_wrong else "JMux"
+            wrong_set = jmux_main_type_set if pydantic_wrong else pydantic_main_type_set
+            raise ForbiddenTypeHintsError(
+                message=(f"Forbidden typing received on {wrong_obj}: {wrong_set}"),
+            )
+
+    @classmethod
+    def _assert_only_allowed_types(
+        cls,
+        jmux_main_type_set: Set[Type],
+        jmux_subtype_set: Set[Type],
+        pydantic_main_type_set: Set[Type],
+        pydantic_subtype_set: Set[Type],
+    ) -> None:
+        if not all(t in (AwaitableValue, StreamableValues) for t in jmux_main_type_set):
+            raise ForbiddenTypeHintsError(
+                message=(
+                    "JMux must have either AwaitableValue or StreamableValues as "
+                    f"main type, got {jmux_main_type_set}."
+                )
+            )
+
+        if not any(
+            issubclass(elem, t)
+            for t in (int, float, str, bool, NoneType, JMux, Enum)
+            for elem in jmux_subtype_set
+        ):
+            raise ForbiddenTypeHintsError(
+                message=(
+                    "JMux sub type must be one of the emittable types: "
+                    f"{jmux_subtype_set}."
+                )
+            )
+
+        if len(pydantic_subtype_set) > 0 and not any(
+            issubclass(elem, t)
+            for t in (int, float, str, bool, NoneType, BaseModel, Enum)
+            for elem in pydantic_subtype_set
+        ):
+            raise ForbiddenTypeHintsError(
+                message=(
+                    "Pydantic sub type must be one of the primitive, enum or "
+                    f"BaseModel, got: {pydantic_subtype_set}."
+                )
+            )
+
+        if not any(
+            issubclass(elem, t)
+            for t in (int, float, str, bool, list, NoneType, BaseModel, Enum)
+            for elem in pydantic_main_type_set
+        ):
+            raise ForbiddenTypeHintsError(
+                message=(
+                    "Pydantic main type must be one of the primitive, enum, list "
+                    f"or BaseModel, got {pydantic_main_type_set}."
+                )
+            )
 
     @classmethod
     def _assert_is_allowed_streamable_values(
@@ -327,58 +392,6 @@ class JMux(ABC):
                     f"AwaitableValue with type {jmux_subtype_set} does not match "
                     f"pydantic model type: {pydantic_main_type_set}"
                 ),
-            )
-
-    @classmethod
-    def _assert_only_allowed_types(
-        cls,
-        jmux_main_type_set: Set[Type],
-        jmux_subtype_set: Set[Type],
-        pydantic_main_type_set: Set[Type],
-        pydantic_subtype_set: Set[Type],
-    ) -> None:
-        if not all(t in (AwaitableValue, StreamableValues) for t in jmux_main_type_set):
-            raise ForbiddenTypeHintsError(
-                message=(
-                    "JMux must have either AwaitableValue or StreamableValues as "
-                    f"main type, got {jmux_main_type_set}."
-                )
-            )
-
-        if not any(
-            issubclass(elem, t)
-            for t in (int, float, str, bool, NoneType, JMux, Enum)
-            for elem in jmux_subtype_set
-        ):
-            raise ForbiddenTypeHintsError(
-                message=(
-                    "JMux sub type must be one of the emittable types: "
-                    f"{jmux_subtype_set}."
-                )
-            )
-
-        if len(pydantic_subtype_set) > 0 and not any(
-            issubclass(elem, t)
-            for t in (int, float, str, bool, NoneType, BaseModel, Enum)
-            for elem in pydantic_subtype_set
-        ):
-            raise ForbiddenTypeHintsError(
-                message=(
-                    "Pydantic sub type must be one of the primitive, enum or "
-                    f"BaseModel, got: {pydantic_subtype_set}."
-                )
-            )
-
-        if not any(
-            issubclass(elem, t)
-            for t in (int, float, str, bool, list, NoneType, BaseModel, Enum)
-            for elem in pydantic_main_type_set
-        ):
-            raise ForbiddenTypeHintsError(
-                message=(
-                    "Pydantic main type must be one of the primitive, enum, list "
-                    f"or BaseModel, got {pydantic_main_type_set}."
-                )
             )
 
     async def feed_chunks(self, chunks: str) -> None:
@@ -556,7 +569,10 @@ class JMux(ABC):
                             await self._parse_primitive()
                             await self._sink.close()
                             self._decoder.reset()
-                            self._pda.set_state(S.EXPECT_KEY)
+                            if ch in JSON_WHITESPACE:
+                                self._pda.set_state(S.EXPECT_COMMA_OR_EOC)
+                            else:
+                                self._pda.set_state(S.EXPECT_KEY)
                             if ch in OBJECT_CLOSE:
                                 await self._finalize()
                         else:

--- a/src/jmux/types.py
+++ b/src/jmux/types.py
@@ -1,5 +1,6 @@
 from enum import Enum
-from typing import Set
+from types import NoneType, UnionType
+from typing import List, Set, Union
 
 
 class State(Enum):
@@ -56,3 +57,7 @@ JSON_FALSE = "false"
 JSON_TRUE = "true"
 JSON_NULL = "null"
 JSON_WHITESPACE = set(" \t\n\r")
+
+TYPES_LIKE_UNION = {UnionType, Union}
+TYPES_LIKE_NONE = {NoneType, None}
+TYPES_LIKE_LIST = {List, list}

--- a/tests/test_demux__parse.py
+++ b/tests/test_demux__parse.py
@@ -282,7 +282,7 @@ parse_incorrect_stream__params = [
     parse_incorrect_stream__params,
 )
 @pytest.mark.anyio
-async def test_json_demux__parse_incorrect_stream__assert_error(
+async def test_json_demux__parse_stream__assert_error(
     stream: str, MaybeExpectedError: Type[Exception] | None
 ):
     class SObject(JMux):
@@ -375,7 +375,7 @@ parse_incorrect_stream_with_optionals__params = [
     parse_incorrect_stream_with_optionals__params,
 )
 @pytest.mark.anyio
-async def test_json_demux__parse_incorrect_stream_with_optionals__assert_error(
+async def test_json_demux__parse_stream_with_optionals__assert_error(
     stream: str, MaybeExpectedError: Type[Exception] | None
 ):
     class SObject(JMux):
@@ -416,6 +416,10 @@ parse_correct_stream__double_nested__params = [
     ('{"key_first_nested": {"key_second_nested": {"key_str": "val"}, "key_str": "val', None),
     ('{"key_first_nested": {"key_second_nested": {"key_str": "val"}, "key_str": "val"}', None),
     ('{"key_first_nested": {"key_second_nested": {"key_str": "val"}, "key_str": "val"}}', None),
+    ('{"key_first_nested": {"key_second_nested": {"key_str": "val"}, "key_str": null}}', None),
+    ('{"key_first_nested": {"key_second_nested": {"key_str": "val"}, "key_str": null\n}}', None),
+    ('{"key_first_nested": null}', None),
+    ('{"key_first_nested": null\n}', None),
 ]
 # fmt: on
 @pytest.mark.parametrize(
@@ -423,7 +427,7 @@ parse_correct_stream__double_nested__params = [
     parse_correct_stream__double_nested__params,
 )
 @pytest.mark.anyio
-async def test_json_demux__parse_correct_stream__double_nested(
+async def test_json_demux__parse_stream__double_nested(
     stream: str, MaybeExpectedError: Type[Exception] | None
 ):
     class SObject(JMux):

--- a/tests/test_demux__validate.py
+++ b/tests/test_demux__validate.py
@@ -72,6 +72,14 @@ class CorrectPydantic_2(BaseModel):
     key_bool: bool | None
 
 
+class CorrectJMux_3(JMux):
+    arr_str: StreamableValues[str]
+
+
+class CorrectPydantic_3(BaseModel):
+    arr_str: list[str] | None
+
+
 class IncorrectJMux_1(JMux):
     key_str: AwaitableValue[str]
 
@@ -107,6 +115,7 @@ class IncorrectPydantic_3(BaseModel):
     [
         (CorrectJMux_1, CorrectPydantic_1, None),
         (CorrectJMux_2, CorrectPydantic_2, None),
+        (CorrectJMux_3, CorrectPydantic_3, None),
         (IncorrectJMux_1, IncorrectPydantic_1, ObjectMissmatchedError),
         (IncorrectJMux_2, IncorrectPydantic_2, ObjectMissmatchedError),
         (IncorrectJMux_3, IncorrectPydantic_3, ObjectMissmatchedError),


### PR DESCRIPTION
This PR does two things:
1. Allow for `Optional` on Pydantic for Lists, so if the `JMux`  type is `arr_str: StreamableValues[str]` the Pydantic type is now allowed to be `arr_str: list[str] | None` not just `arr_str: list[str]`
2. Fixes a reported but where a trailing whitespace after a `null` value created an `UnexpectedCharacterError`